### PR TITLE
Fix for email links in user profile

### DIFF
--- a/protected/modules_core/user/models/ProfileFieldTypeText.php
+++ b/protected/modules_core/user/models/ProfileFieldTypeText.php
@@ -178,7 +178,7 @@ class ProfileFieldTypeText extends ProfileFieldType {
         $value = $user->profile->$internalName;
 
         if (!$raw && $this->validator == self::VALIDATOR_EMAIL) {
-            return HHtml::link($value, $value);
+            return HHtml::link($value, 'mailto:'.$value);
         } elseif (!$raw && $this->validator == self::VALIDATOR_URL) {
             return HHtml::link($value, $value, array('target'=> '_blank'));
         }


### PR DESCRIPTION
HHtml::link($value, $value) only appends field value to the actual url path. We have to set the (right) URI protocol to prevent this.
